### PR TITLE
Simplify MOTD messages by dropping priority field

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A simple and powerful Message of the Day (MOTD) app for Alliance Auth that displ
 ## Features
 
 - **Dashboard Widget**: Shows current MOTD messages on the main Alliance Auth dashboard
-- **Priority System**: Critical, High, Normal, and Low priority messages with visual indicators
 - **Flexible Scheduling**: Set start and end dates for messages
 - **Group Restrictions**: Show messages only to specific groups or to all users
 - **Multiple Styles**: Bootstrap alert styles (info, success, warning, danger)
@@ -83,14 +82,7 @@ Set up a periodic task to clean up expired messages:
 
 2. **Scheduling**: Set start and end dates to control when messages appear
 3. **Targeting**: Use group restrictions to show messages only to specific groups
-4. **Styling**: Choose appropriate priority levels and Bootstrap styles for visual impact
-
-## Message Priorities
-
-- **Critical**: Red warning icon, highest priority
-- **High**: Orange exclamation, high priority  
-- **Normal**: Blue bullhorn, standard priority
-- **Low**: Gray info icon, lowest priority
+4. **Styling**: Choose appropriate Bootstrap alert styles for visual impact
 
 ## Requirements
 

--- a/motd/admin.py
+++ b/motd/admin.py
@@ -8,7 +8,6 @@ from .models import MotdMessage
 class MotdMessageAdmin(admin.ModelAdmin):
     list_display = [
         'title',
-        'priority',
         'style',
         'is_active',
         'start_date',
@@ -18,7 +17,6 @@ class MotdMessageAdmin(admin.ModelAdmin):
         'status_display',
     ]
     list_filter = [
-        'priority',
         'style',
         'is_active',
         'show_to_all',
@@ -32,7 +30,7 @@ class MotdMessageAdmin(admin.ModelAdmin):
         (
             'Message Content',
             {
-                'fields': ['title', 'content', 'priority', 'style'],
+                'fields': ['title', 'content', 'style'],
             },
         ),
         (

--- a/motd/auth_hooks.py
+++ b/motd/auth_hooks.py
@@ -2,10 +2,9 @@ from allianceauth import hooks
 from allianceauth.services.hooks import MenuItemHook, UrlHook
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
+
 from . import urls
 from .models import MotdMessage
-from django.utils.translation import gettext_lazy as _
-from . import urls
 
 class MotdMenuItemHook(MenuItemHook):
     def __init__(self):
@@ -38,14 +37,9 @@ def register_dashboard(request):
 
     active_messages = [
         message
-        for message in MotdMessage.objects.filter(is_active=True)
+        for message in MotdMessage.objects.filter(is_active=True).order_by('-start_date')
         if message.can_user_see(request.user)
     ]
-
-    priority_order = {'critical': 4, 'high': 3, 'normal': 2, 'low': 1}
-    active_messages.sort(
-        key=lambda x: priority_order.get(x.priority, 0), reverse=True
-    )
 
     context = {
         'messages': active_messages[:5],

--- a/motd/forms.py
+++ b/motd/forms.py
@@ -9,7 +9,6 @@ class MotdMessageForm(forms.ModelForm):
         fields = [
             "title",
             "content",
-            "priority",
             "style",
             "start_date",
             "end_date",

--- a/motd/migrations/0001_initial.py
+++ b/motd/migrations/0001_initial.py
@@ -1,22 +1,15 @@
+from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
-from django.conf import settings
 import django.utils.timezone
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [
         ('auth', '0012_alter_user_first_name_max_length'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-
-class Migration(migrations.Migration):
-    initial = True
-
-    dependencies = [
-        ('auth', '0001_initial'),
     ]
 
     operations = [
@@ -26,22 +19,67 @@ class Migration(migrations.Migration):
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('title', models.CharField(help_text='Title of the MOTD message', max_length=200)),
                 ('content', models.TextField(help_text='Message content (HTML allowed)')),
-                ('priority', models.CharField(choices=[('low', 'Low'), ('normal', 'Normal'), ('high', 'High'), ('critical', 'Critical')], default='normal', help_text='Message priority level', max_length=10)),
-                ('style', models.CharField(choices=[('info', 'Info (Blue)'), ('success', 'Success (Green)'), ('warning', 'Warning (Yellow)'), ('danger', 'Danger (Red)')], default='info', help_text='Bootstrap alert style', max_length=10)),
+                (
+                    'style',
+                    models.CharField(
+                        choices=[
+                            ('info', 'Info (Blue)'),
+                            ('success', 'Success (Green)'),
+                            ('warning', 'Warning (Yellow)'),
+                            ('danger', 'Danger (Red)')
+                        ],
+                        default='info',
+                        help_text='Bootstrap alert style',
+                        max_length=10,
+                    ),
+                ),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('updated_at', models.DateTimeField(auto_now=True)),
-                ('start_date', models.DateTimeField(default=django.utils.timezone.now, help_text='When this message should start displaying')),
-                ('end_date', models.DateTimeField(blank=True, help_text='When this message should stop displaying (leave blank for permanent)', null=True)),
+                (
+                    'start_date',
+                    models.DateTimeField(
+                        default=django.utils.timezone.now,
+                        help_text='When this message should start displaying',
+                    ),
+                ),
+                (
+                    'end_date',
+                    models.DateTimeField(
+                        blank=True,
+                        help_text='When this message should stop displaying (leave blank for permanent)',
+                        null=True,
+                    ),
+                ),
                 ('is_active', models.BooleanField(default=True, help_text='Whether this message is active')),
-                ('show_to_all', models.BooleanField(default=True, help_text='Show to all authenticated users')),
-                ('created_by', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='created_motd_messages', to=settings.AUTH_USER_MODEL)),
-                ('restricted_to_groups', models.ManyToManyField(blank=True, help_text='If specified, only show to users in these groups', to='auth.group')),
+                (
+                    'show_to_all',
+                    models.BooleanField(default=True, help_text='Show to all authenticated users'),
+                ),
+                (
+                    'created_by',
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name='created_motd_messages',
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    'restricted_to_groups',
+                    models.ManyToManyField(
+                        blank=True,
+                        help_text='If specified, only show to users in these groups',
+                        to='auth.group',
+                    ),
+                ),
             ],
             options={
                 'verbose_name': 'MOTD Message',
                 'verbose_name_plural': 'MOTD Messages',
-                'ordering': ['-priority', '-start_date'],
-
+                'ordering': ['-start_date'],
+            },
+        ),
+        migrations.CreateModel(
             name='GroupMotd',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
@@ -55,4 +93,19 @@ class Migration(migrations.Migration):
                 'ordering': ['group__name'],
             },
         ),
+        migrations.CreateModel(
+            name='StateMotd',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('state_name', models.CharField(max_length=64, unique=True)),
+                ('message', models.TextField()),
+                ('enabled', models.BooleanField(default=True)),
+            ],
+            options={
+                'verbose_name': 'State MOTD',
+                'verbose_name_plural': 'State MOTDs',
+                'ordering': ['state_name'],
+            },
+        ),
     ]
+

--- a/motd/models.py
+++ b/motd/models.py
@@ -7,13 +7,6 @@ from django.utils import timezone
 class MotdMessage(models.Model):
     """Model for storing MOTD messages"""
 
-    PRIORITY_CHOICES = [
-        ('low', 'Low'),
-        ('normal', 'Normal'),
-        ('high', 'High'),
-        ('critical', 'Critical'),
-    ]
-
     STYLE_CHOICES = [
         ('info', 'Info (Blue)'),
         ('success', 'Success (Green)'),
@@ -23,12 +16,6 @@ class MotdMessage(models.Model):
 
     title = models.CharField(max_length=200, help_text="Title of the MOTD message")
     content = models.TextField(help_text="Message content (HTML allowed)")
-    priority = models.CharField(
-        max_length=10,
-        choices=PRIORITY_CHOICES,
-        default='normal',
-        help_text="Message priority level",
-    )
     style = models.CharField(
         max_length=10,
         choices=STYLE_CHOICES,
@@ -67,12 +54,12 @@ class MotdMessage(models.Model):
     )
 
     class Meta:
-        ordering = ['-priority', '-start_date']
+        ordering = ['-start_date']
         verbose_name = "MOTD Message"
         verbose_name_plural = "MOTD Messages"
 
     def __str__(self):
-        return f"{self.title} ({self.get_priority_display()})"
+        return f"{self.title} ({self.get_style_display()})"
 
     def clean(self):
         if self.end_date and self.end_date <= self.start_date:
@@ -105,8 +92,6 @@ class MotdMessage(models.Model):
             return self.restricted_to_groups.filter(id__in=user_groups).exists()
 
         return False
-
-from django.contrib.auth.models import Group
 
 
 class GroupMotd(models.Model):

--- a/motd/templates/motd/dashboard_widget.html
+++ b/motd/templates/motd/dashboard_widget.html
@@ -9,17 +9,17 @@
             <div class="motd-messages">
                 {% if messages %}
                     {% for message in messages %}
-                        <div class="alert alert-{{ message.style }} motd-alert" data-priority="{{ message.priority }}">
+                        <div class="alert alert-{{ message.style }} motd-alert">
                             <div class="motd-content">
                                 <h6 class="alert-heading mb-2">
-                                    {% if message.priority == 'critical' %}
+                                    {% if message.style == 'danger' %}
                                         <i class="fas fa-exclamation-triangle"></i>
-                                    {% elif message.priority == 'high' %}
+                                    {% elif message.style == 'warning' %}
                                         <i class="fas fa-exclamation-circle"></i>
-                                    {% elif message.priority == 'low' %}
-                                        <i class="fas fa-info-circle"></i>
+                                    {% elif message.style == 'success' %}
+                                        <i class="fas fa-check-circle"></i>
                                     {% else %}
-                                        <i class="fas fa-bullhorn"></i>
+                                        <i class="fas fa-info-circle"></i>
                                     {% endif %}
                                     {{ message.title }}
                                 </h6>
@@ -28,7 +28,7 @@
                                 </div>
                                 {% if message.end_date %}
                                     <small class="text-muted d-block mt-2">
-                                        <i class="fas fa-clock"></i> 
+                                        <i class="fas fa-clock"></i>
                                         Expires: {{ message.end_date|date:"M d, Y H:i" }}
                                     </small>
                                 {% endif %}
@@ -63,24 +63,24 @@
     border-left: 4px solid;
 }
 
-.motd-alert[data-priority="critical"] {
+.motd-alert.alert-danger {
     border-left-color: #dc3545;
     box-shadow: 0 2px 4px rgba(220, 53, 69, 0.1);
 }
 
-.motd-alert[data-priority="high"] {
+.motd-alert.alert-warning {
     border-left-color: #fd7e14;
     box-shadow: 0 2px 4px rgba(253, 126, 20, 0.1);
 }
 
-.motd-alert[data-priority="normal"] {
+.motd-alert.alert-info {
     border-left-color: #0d6efd;
     box-shadow: 0 2px 4px rgba(13, 110, 253, 0.1);
 }
 
-.motd-alert[data-priority="low"] {
-    border-left-color: #6c757d;
-    box-shadow: 0 2px 4px rgba(108, 117, 125, 0.1);
+.motd-alert.alert-success {
+    border-left-color: #198754;
+    box-shadow: 0 2px 4px rgba(25, 135, 84, 0.1);
 }
 
 .motd-content h6.alert-heading {

--- a/motd/templates/motd/motd_list.html
+++ b/motd/templates/motd/motd_list.html
@@ -19,23 +19,23 @@
             {% if messages %}
                 <div class="motd-list">
                     {% for message in messages %}
-                        <div class="card mb-3 motd-message-card" data-priority="{{ message.priority }}">
+                        <div class="card mb-3 motd-message-card border-start border-4 border-{{ message.style }}">
                             <div class="card-body">
                                 <div class="d-flex justify-content-between align-items-start">
                                     <h5 class="card-title">
-                                        {% if message.priority == 'critical' %}
+                                        {% if message.style == 'danger' %}
                                             <i class="fas fa-exclamation-triangle text-danger"></i>
-                                        {% elif message.priority == 'high' %}
+                                        {% elif message.style == 'warning' %}
                                             <i class="fas fa-exclamation-circle text-warning"></i>
-                                        {% elif message.priority == 'low' %}
-                                            <i class="fas fa-info-circle text-muted"></i>
+                                        {% elif message.style == 'success' %}
+                                            <i class="fas fa-check-circle text-success"></i>
                                         {% else %}
-                                            <i class="fas fa-bullhorn text-primary"></i>
+                                            <i class="fas fa-info-circle text-info"></i>
                                         {% endif %}
                                         {{ message.title }}
 
                                         <span class="badge bg-{{ message.style }} ms-2">
-                                            {{ message.get_priority_display }}
+                                            {{ message.get_style_display }}
                                         </span>
                                     </h5>
                                 </div>
@@ -80,21 +80,7 @@
 </div>
 
 <style>
-.motd-message-card[data-priority="critical"] {
-    border-left: 4px solid #dc3545;
-}
-
-.motd-message-card[data-priority="high"] {
-    border-left: 4px solid #fd7e14;
-}
-
-.motd-message-card[data-priority="normal"] {
-    border-left: 4px solid #0d6efd;
-}
-
-.motd-message-card[data-priority="low"] {
-    border-left: 4px solid #6c757d;
-}
+/* border color handled via Bootstrap utility classes */
 
 .motd-meta {
     font-size: 0.875rem;

--- a/motd/urls.py
+++ b/motd/urls.py
@@ -4,10 +4,8 @@ from . import views
 app_name = 'motd'
 
 urlpatterns = [
-    path('', views.motd_list, name='list'),
-    path('widget/', views.dashboard_widget, name='dashboard_widget'),
-    path('create/', views.motd_create, name='create'),
-
-urlpatterns = [
     path("", views.motd_dashboard, name="motd-dashboard"),
+    path("list/", views.motd_list, name="list"),
+    path("widget/", views.dashboard_widget, name="dashboard_widget"),
+    path("create/", views.motd_create, name="create"),
 ]


### PR DESCRIPTION
## Summary
- drop priority attribute from MOTD messages and related admin/form logic
- sort messages only by start date and display icons/colors based on style
- update docs and templates to use Bootstrap styles instead of priority levels

## Testing
- `python -m py_compile motd/models.py motd/forms.py motd/admin.py motd/views.py motd/auth_hooks.py motd/urls.py motd/migrations/0001_initial.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a56337018832c9fe6e2c9996dbd58