### PR TITLE
Order MOTD dashboard messages by start date

### DIFF
--- a/motd/auth_hooks.py
+++ b/motd/auth_hooks.py
@@ -31,18 +31,6 @@ def register_menu():
 def register_url():
     return UrlHook(urls, 'motd', r'^motd/')
 
-    active_messages = [
-        message
-        for message in MotdMessage.objects.filter(is_active=True).order_by('-start_date')
-        if message.can_user_see(request.user)
-    ]
-
-    context = {
-        'messages': active_messages[:5],
-        'user': request.user,
-    }
-    return render_to_string('motd/dashboard_widget.html', context, request=request)
-
 class MotdDashboardItemHook:
     def __init__(self):
         self.name = 'MOTD Widget'
@@ -55,14 +43,9 @@ class MotdDashboardItemHook:
 
         active_messages = [
             message
-            for message in MotdMessage.objects.filter(is_active=True)
+            for message in MotdMessage.objects.filter(is_active=True).order_by('-start_date')
             if message.can_user_see(request.user)
         ]
-
-        priority_order = {'critical': 4, 'high': 3, 'normal': 2, 'low': 1}
-        active_messages.sort(
-            key=lambda x: priority_order.get(x.priority, 0), reverse=True
-        )
 
         # Pass permission check result to template
         context = {


### PR DESCRIPTION
## Summary
- Order MOTD dashboard widget messages by `start_date`
- Remove unused priority sorting logic

## Testing
- `python manage.py check` *(fails: can't open file '/workspace/Motd/manage.py')*

------
https://chatgpt.com/codex/tasks/task_e_689b857c0a4c832ca9d47b3c6a2dcf27