### PR TITLE
Use perms in MOTD list template

### DIFF
--- a/motd/templates/motd/motd_list.html
+++ b/motd/templates/motd/motd_list.html
@@ -8,7 +8,7 @@
     <div class="row">
         <div class="col-12">
             {% include "framework/page-header.html" with title="Message of the Day" %}
-            {% if user.has_perm('motd.add_motdmessage') %}
+            {% if perms.motd.add_motdmessage %}
                 <div class="mb-3 text-end">
                     <a href="{% url 'motd:create' %}" class="btn btn-sm btn-success">
                         <i class="fas fa-plus"></i> Add Message


### PR DESCRIPTION
## Summary
- use `perms.motd.add_motdmessage` for template permission check

## Testing
- `python manage.py check` *(fails: can't open file '/workspace/Motd/manage.py')*

