### PR TITLE
Use Alliance Auth page header partial in MOTD templates

### DIFF
--- a/motd/templates/motd/motd_form.html
+++ b/motd/templates/motd/motd_form.html
@@ -7,7 +7,7 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-12">
-      {% include "framework/page-header.html" with title="Create MOTD" %}
+      {% include "allianceauth/partials/page_header.html" with title="Create MOTD" %}
       <form method="post">
         {% csrf_token %}
         {{ form.as_p }}

--- a/motd/templates/motd/motd_list.html
+++ b/motd/templates/motd/motd_list.html
@@ -7,7 +7,7 @@
 <div class="container-fluid">
     <div class="row">
         <div class="col-12">
-            {% include "framework/page-header.html" with title="Message of the Day" %}
+            {% include "allianceauth/partials/page_header.html" with title="Message of the Day" %}
             {% if perms.motd.add_motdmessage %}
                 <div class="mb-3 text-end">
                     <a href="{% url 'motd:create' %}" class="btn btn-sm btn-success">


### PR DESCRIPTION
## Summary
- Use Alliance Auth page_header partial in MOTD list and form templates

## Testing
- `python manage.py check` *(fails: can't open file 'manage.py')*

