### PR TITLE
Add internal page header partial

### DIFF
--- a/motd/templates/motd/motd_form.html
+++ b/motd/templates/motd/motd_form.html
@@ -7,7 +7,7 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-12">
-      {% include "allianceauth/partials/page_header.html" with title="Create MOTD" %}
+      {% include "motd/partials/page_header.html" with title="Create MOTD" %}
       <form method="post">
         {% csrf_token %}
         {{ form.as_p }}

--- a/motd/templates/motd/motd_list.html
+++ b/motd/templates/motd/motd_list.html
@@ -7,7 +7,7 @@
 <div class="container-fluid">
     <div class="row">
         <div class="col-12">
-            {% include "allianceauth/partials/page_header.html" with title="Message of the Day" %}
+            {% include "motd/partials/page_header.html" with title="Message of the Day" %}
             {% if perms.motd.add_motdmessage %}
                 <div class="mb-3 text-end">
                     <a href="{% url 'motd:create' %}" class="btn btn-sm btn-success">

--- a/motd/templates/partials/page_header.html
+++ b/motd/templates/partials/page_header.html
@@ -1,0 +1,4 @@
+{% comment %}Mirrors Alliance Auth's page header layout{% endcomment %}
+<div class="d-flex align-items-center justify-content-between mb-3">
+  <h1 class="h3">{{ title }}</h1>
+</div>


### PR DESCRIPTION
## Summary
- add MOTD-specific `page_header` partial matching Alliance Auth style
- update MOTD list and form templates to use the new partial

## Testing
- `python manage.py check` *(fails: can't open file 'manage.py')*

------
https://chatgpt.com/codex/tasks/task_e_689b9ad60398832c89caa18cd20c6541