### PR TITLE
[CHANGE] Use Tag Logger

### DIFF
--- a/motd/views.py
+++ b/motd/views.py
@@ -19,8 +19,6 @@ from motd.models import MotdMessage
 
 logger = LoggerAddTag(get_extension_logger(__name__), __title__)
 
-logger = logging.getLogger(__name__)
-
 
 @login_required
 @permission_required("motd.basic_access")


### PR DESCRIPTION
## Description

### Changed

- remove logger and use AA Logger

### Explanation

If you use the AA Logger you have a better logging and users can better give log error back cause it names your app etc.
You can find your logs in gunicorn.log or extensions.log

If you want a own logger you can also use 


```
LOGGING["handlers"]["motd_file"] = {
    "level": "DEBUG",
    "class": "logging.handlers.RotatingFileHandler",
    "filename": os.path.join(BASE_DIR, "log/motd.log"),
    "formatter": "verbose",
    "maxBytes": 1024 * 1024 * 5,
    "backupCount": 5,
}
LOGGING["loggers"]["extensions.motd"] = {
    "handlers": ["motd_file", "console", "extension_file"],
    "level": "DEBUG",
}
```

This need to be added in the local.py

<img width="925" height="179" alt="Screenshot 2025-08-18 093743" src="https://github.com/user-attachments/assets/1c73e6c4-bfa1-4509-adb8-421aaf7a08a2" />

## Type of Changes
Please select the type of changes made in this pull request:
- [x] Bug Fix (non-breaking change which fixes an Issue)
- [x] New Feature (non-breaking change)
- [x] Other (please specify):

## Checklist
Please ensure the following before submitting your pull request:
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] All new and existing tests passed.
